### PR TITLE
use constant instead of sizeof(array)

### DIFF
--- a/ZXingObjC/datamatrix/decoder/ZXDataMatrixDecodedBitStreamParser.m
+++ b/ZXingObjC/datamatrix/decoder/ZXDataMatrixDecodedBitStreamParser.m
@@ -243,7 +243,7 @@ enum {
         shift = 0;
         break;
       case 2:
-        if (cValue < sizeof(C40_SHIFT2_SET_CHARS) / sizeof(unichar)) {
+        if (cValue < 27) {
           unichar c40char = C40_SHIFT2_SET_CHARS[cValue];
           if (upperShift) {
             [result appendFormat:@"%C", (unichar)(c40char + 128)];
@@ -331,7 +331,7 @@ enum {
         break;
       case 2:
           // Shift 2 for Text is the same encoding as C40
-        if (cValue < sizeof(TEXT_SHIFT2_SET_CHARS) / sizeof(unichar)) {
+        if (cValue < 27) {
           unichar textChar = TEXT_SHIFT2_SET_CHARS[cValue];
           if (upperShift) {
             [result appendFormat:@"%C", (unichar)(textChar + 128)];


### PR DESCRIPTION
This commit fixes 2 occurrences of sizeof(array) which have been used to replace the upstream use of the Java Array.length function.
It happens that in Objective-C sizeof returns the number of the allocated cells while in Java length returns the actual number of entries.
The array here has more allocated than used cells (40 vs 27) which means that the subsequent else clauses are never reached and some symbols like the FNC1 character are interpreted incorrectly. 
A constant value (27) has been used as a solution like in the following else statement. The alternative to set the array allocation to 27 seems to be dangerous in regard to subsequent changes by unaware developers.